### PR TITLE
preserve xattrs and remove top-level directory from tarball

### DIFF
--- a/mkdebianrfs.sh
+++ b/mkdebianrfs.sh
@@ -244,7 +244,7 @@ echo
 
 if [ -n "${target_tar}" ]; then
     echo "Creating ${target_tar}..."
-    tar -capf "${target_tar}" -C "${tmp_dir}" "${tar_dir}"
+    tar -capf "${target_tar}" --xattrs -C "${tmp_dir}/${tar_dir}" .
 fi
 
 cleanup


### PR DESCRIPTION
This worked smoothly for me, but i didn't quite expect the top-level directory (most other roots I use only have ./ so I'm used to untar with -C /mnt/rootfs or similar) plus it's a good idea to preserve attributes for things like pax, etc.  Thanks!
